### PR TITLE
closes the view controller after receiving nameLink

### DIFF
--- a/SafariAutoLoginTest/ViewController.swift
+++ b/SafariAutoLoginTest/ViewController.swift
@@ -44,6 +44,7 @@ class ViewController: UIViewController, SFSafariViewControllerDelegate {
     }
 
     func safariViewControllerDidFinish(controller: SFSafariViewController) {
+        controller.dismissViewControllerAnimated(false, completion: nil)
         self.safari = nil
     }
 
@@ -53,6 +54,9 @@ class ViewController: UIViewController, SFSafariViewControllerDelegate {
                 nameLabel.text = "You are \(name)!"
             } else {
                 nameLabel.text = "I don't know who you are :("
+            }
+            if let safari = self.safari {
+                safariViewControllerDidFinish(safari)
             }
         }
     }


### PR DESCRIPTION
When I run the demo with the SFSafariViewController visible, it appears to hang around after the name is updated. I made this change to dismiss the SFSafariViewController after that has happened.
